### PR TITLE
Update service type to LoadBalancer for external IP

### DIFF
--- a/sample-app/service.yaml
+++ b/sample-app/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: sample-app
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 80
     targetPort: 80


### PR DESCRIPTION
Change the service type to `LoadBalancer` in `sample-app/service.yaml` to expose an external IP address.

* Update the `type` field from `ClusterIP` to `LoadBalancer` in the service specification.
* Ensure the `ports` section remains unchanged to continue exposing port 80.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/orsharon7/sample-app/pull/4?shareId=2c511ff9-7037-40b1-8ce9-1b7181a1227c).